### PR TITLE
This patch fixes an issue that occurs with a non-English locale

### DIFF
--- a/plugin/dbgpavim.vim
+++ b/plugin/dbgpavim.vim
@@ -257,11 +257,11 @@ function! Signs()
   let l:bpts = {}
   let l:lines = split(l:signs, '\n')
   for l:line in l:lines
-    if l:line =~ "^Signs for \\S*:$"
+    if l:line =~ "\\S*:$"
       let l:file = expand("%:p")
-    elseif l:line =~ "^\\s*line=\\d*\\s*id=\\d*\\s*name=breakpt$"
-      let l:lno = substitute(l:line,"^\\s*line=\\(\\d\\+\\)\\s*id=\\d*\\s*name=breakpt$", "\\1", "g")
-      let l:id = substitute(l:line,"^\\s*line=\\d\\+\\s*id=\\(\\d\\+\\)\\s*name=breakpt$", "\\1", "g")
+    elseif l:line =~ "^\\s*\\S*=\\d*\\s*\\S*=\\d*\\s*\\S*=breakpt$"
+      let l:lno = substitute(l:line,"^\\s*\\S*=\\(\\d\\+\\)\\s*\\S*=\\d*\\s*\\S*=breakpt$", "\\1", "g")
+      let l:id = substitute(l:line,"^\\s*\\S*=\\d\\+\\s*\\S*=\\(\\d\\+\\)\\s*\\S*=breakpt$", "\\1", "g")
       let l:bpts[l:id] = [l:file, l:lno]
     endif
   endfor


### PR DESCRIPTION
it is impossible to remove the previously set breakpoint If vim is working with non-English locale. This is because the function 'Signs()' uses the output of the command ':sign place'. But the output of the command ':sign place' depends on the locale.

This patch removes the dependency on the locale. Tested for EN and RU locales.

Thanks for your great work.
