### PR TITLE
Ignore doc/tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,0 @@
-dbgpavim	dbgpavim.txt	/*DBGPavim*
-dbgpavim-commands	dbgpavim.txt	/*commands*
-dbgpavim-status	dbgpavim.txt	/*Status*
-dbgpavim-usage	dbgpavim.txt	/*Usage*


### PR DESCRIPTION
I manage my Vim plugins using Pathogen and git submodules and every time I run git diff inside the DBGPavim directory, I get this:

``` diff
diff --git doc/tags doc/tags
index 3bdd055..86af737 100644
--- doc/tags
+++ doc/tags
@@ -1,4 +1,5 @@
-dbgpavim       dbgpavim.txt    /*DBGPavim*
-dbgpavim-commands      dbgpavim.txt    /*commands*
-dbgpavim-status        dbgpavim.txt    /*Status*
-dbgpavim-usage dbgpavim.txt    /*Usage*
+DBGPavim       dbgpavim.txt    /*DBGPavim*
+Status dbgpavim.txt    /*Status*
+Usage  dbgpavim.txt    /*Usage*
+commands       dbgpavim.txt    /*commands*
+enhancements   dbgpavim.txt    /*enhancements*
```

Since `docs/tags` seems to be generated automatically, I think it should be ignored.
